### PR TITLE
Normalize WSD

### DIFF
--- a/notebooks/Bert_as_LM_raw.ipynb
+++ b/notebooks/Bert_as_LM_raw.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "scrolled": true
    },
@@ -37,17 +37,17 @@
     "\n",
     "# Load pre-trained model (weights)\n",
     "with torch.no_grad():\n",
-    "#     model = BertForMaskedLM.from_pretrained('bert-large-uncased')\n",
-    "    model = BertForMaskedLM.from_pretrained('bert-base-uncased')\n",
+    "    model = BertForMaskedLM.from_pretrained('bert-large-uncased')\n",
+    "#     model = BertForMaskedLM.from_pretrained('bert-base-uncased')\n",
     "    model.eval()\n",
     "    # Load pre-trained model tokenizer (vocabulary)\n",
-    "#     tokenizer = BertTokenizer.from_pretrained('bert-large-uncased')\n",
-    "    tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')"
+    "    tokenizer = BertTokenizer.from_pretrained('bert-large-uncased')\n",
+    "#     tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,12 +101,14 @@
     "        print(f\"Raw forward sentence probability: {log_sent_prob_forward}\")\n",
     "        print(f\"Raw backward sentence probability: {log_sent_prob_backwards}\\n\")\n",
     "        print(f\"Average normalized sentence prob: {log_geom_mean_sent_prob}\\n\")\n",
-    "    return np.power(10, log_geom_mean_sent_prob)"
+    "    sentence_prob = np.power(10, log_geom_mean_sent_prob)\n",
+    "    print(sentence_prob)\n",
+    "    return sentence_prob"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,34 +137,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Processing sentence: ['[CLS]', 'he', 'was', 'receiving', 'quite', 'a', 'ridiculous', 'salary', '.', '[SEP]']\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "3.9007599285478314e-20"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "get_sentence_prob(\"He was receiving quite a ridiculous salary.\")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 24,
    "metadata": {},
    "outputs": [
@@ -170,14 +144,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Processing sentence: ['[CLS]', 'he', 'was', 'receiving', 'quite', 'a', 'ridiculous', 'fat', '.', '[SEP]']\n",
-      "\n"
+      "Processing sentence: ['[CLS]', 'the', 'fat', 'cat', 'ate', 'the', 'last', 'mouse', 'quickly', '.', '[SEP]']\n",
+      "\n",
+      "1.5699080230392615e-23\n",
+      "Processing sentence: ['[CLS]', 'there', 'are', 'many', 'health', 'risks', 'associated', 'with', 'fat', '.', '[SEP]']\n",
+      "\n",
+      "8.689618845171052e-20\n",
+      "Processing sentence: ['[CLS]', 'they', 'will', 'fly', 'out', 'of', 'santiago', 'tomorrow', 'morning', '.', '[SEP]']\n",
+      "\n",
+      "3.506387431159266e-22\n",
+      "Processing sentence: ['[CLS]', 'she', 'bought', 'the', 'last', 'microsoft', 'mouse', 'for', 'santiago', '.', '[SEP]']\n",
+      "\n",
+      "2.933483879831623e-28\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0.049579039962200366"
+       "2.933483879831623e-28"
       ]
      },
      "execution_count": 24,
@@ -186,7 +170,92 @@
     }
    ],
    "source": [
-    "get_sentence_prob(\"He was receiving quite a ridiculous fat .\")/3.9007599285478314e-20"
+    "get_sentence_prob(\"The fat cat ate the last mouse quickly.\", verbose=False)\n",
+    "get_sentence_prob(\"There are many health risks associated with fat.\")\n",
+    "get_sentence_prob(\"They will fly out of Santiago tomorrow morning.\")\n",
+    "get_sentence_prob(\"She bought the last Microsoft mouse for Santiago.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.9354396584371938e-23"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.power((1.5699080230392615e-23 * 8.689618845171052e-20 * 3.506387431159266e-22 * 2.933483879831623e-28), 1/4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing sentence: ['[CLS]', 'the', 'deteriorated', 'cat', 'ate', 'the', 'last', 'mouse', 'quickly', '.', '[SEP]']\n",
+      "\n",
+      "1.552863016010471e-26\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.000802330886029461"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_sentence_prob(\"The deteriorated cat ate the last mouse quickly.\")/1.9354396584371938e-23"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing sentence: ['[CLS]', 'there', 'are', 'many', 'health', 'risks', 'associated', 'with', 'time', '.', '[SEP]']\n",
+      "\n",
+      "5.7637240939881745e-22\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "29.779921419209725"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_sentence_prob(\"There are many health risks associated with time.\")/1.9354396584371938e-23"
    ]
   },
   {

--- a/src/word_senser.py
+++ b/src/word_senser.py
@@ -281,15 +281,26 @@ class WordSenseModel:
         return preds_blank_left, preds_blank_right, log_common_prob_forw, log_common_prob_back
 
     def plot_instances(self, embeddings, labels, word):
-        comps = min(3, len(embeddings))
-        pca = PCA(n_components=comps)
+        # PCA processing
+        comps_PCA = min(3, len(embeddings))
+        pca = PCA(n_components=comps_PCA)
         pca_result = pca.fit_transform(embeddings)
         print('Explained variation per principal component: {}'.format(pca.explained_variance_ratio_))
 
+        # t-SNE processing
+        tsne = TSNE(n_components=2, verbose=1, perplexity=40, n_iter=300)
+        tsne_results = tsne.fit_transform(embeddings)
+
+        # PLOTTING
         plt.figure()
+        plt.subplot(211)
         plt.scatter(pca_result[:, 0], pca_result[:, 1], c=labels)
         plt.title(word)
+
+        plt.subplot(212)
+        plt.scatter(tsne_results[:, 0], tsne_results[:, 1], c=labels)
         plt.show()
+        print("PLOTTED")
 
     def disambiguate(self, save_dir, clust_method='OPTICS', freq_threshold=5, pickle_cent='test_cent.pickle', **kwargs):
         """

--- a/src/word_senser.py
+++ b/src/word_senser.py
@@ -11,6 +11,9 @@ import random as rand
 
 from sklearn.cluster import KMeans, OPTICS, DBSCAN
 from sklearn.preprocessing import normalize
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+import matplotlib.pyplot as plt
 from tqdm import tqdm
 import warnings
 
@@ -277,6 +280,17 @@ class WordSenseModel:
 
         return preds_blank_left, preds_blank_right, log_common_prob_forw, log_common_prob_back
 
+    def plot_instances(self, embeddings, labels, word):
+        comps = min(3, len(embeddings))
+        pca = PCA(n_components=comps)
+        pca_result = pca.fit_transform(embeddings)
+        print('Explained variation per principal component: {}'.format(pca.explained_variance_ratio_))
+
+        plt.figure()
+        plt.scatter(pca_result[:, 0], pca_result[:, 1], c=labels)
+        plt.title(word)
+        plt.show()
+
     def disambiguate(self, save_dir, clust_method='OPTICS', freq_threshold=5, pickle_cent='test_cent.pickle', **kwargs):
         """
         Disambiguate word senses through clustering their transformer embeddings.
@@ -325,6 +339,9 @@ class WordSenseModel:
 
             print(f'Disambiguating word \"{word}\"...')
             estimator.fit(curr_embeddings)  # Disambiguate
+            if True:
+                self.plot_instances(curr_embeddings, estimator.labels_, word)
+
             curr_centroids = self.export_clusters(fl, save_to, word, estimator.labels_)
             if len(curr_centroids) > 1:  # Only store centroids for ambiguous words
                 self.cluster_centroids[word] = curr_centroids

--- a/src/word_senser.py
+++ b/src/word_senser.py
@@ -10,6 +10,7 @@ import numpy as np
 import random as rand
 
 from sklearn.cluster import KMeans, OPTICS, DBSCAN
+from sklearn.preprocessing import normalize
 from tqdm import tqdm
 import warnings
 
@@ -316,6 +317,7 @@ class WordSenseModel:
         for word, instances in self.vocab_map.items():
             # Build embeddings list for this word
             curr_embeddings = [self.matrix[row] for _, _, row in instances]
+            curr_embeddings = normalize(curr_embeddings)  # Make unit vectors
 
             if len(curr_embeddings) < freq_threshold:  # Don't disambiguate if word is infrequent
                 print(f"Word \"{word}\" frequency lower than threshold")


### PR DESCRIPTION
Implemented normalization of word-instance embeddings to unit length, to make sense of the comparison between vectors coming from widely varying sentence probabilities.

Also implemented word-embedding projections using PCA and t-SNE.